### PR TITLE
Commit blink; locate HEAD feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.vsix
 
 *.orig
+.vscode/*

--- a/media/main.css
+++ b/media/main.css
@@ -403,6 +403,18 @@ svg.fileIcon {
   border-radius: 11px;
   margin-top: -12px;
 }
+/* Make the Locate HEAD button match the refresh button style but smaller */
+#blinkHeadBtn {
+  position: absolute;
+  right: 96px;
+  top: 50%;
+  width: 120px;
+  height: 22px;
+  line-height: 22px;
+  border-radius: 11px;
+  margin-top: -12px;
+  text-align: center;
+}
 #loadMoreCommitsBtn {
   width: 180px;
   height: 28px;
@@ -557,6 +569,18 @@ svg.fileIcon {
 #actionRunning {
   margin: 0 16px;
   line-height: 24px;
+}
+
+/* Blink animation for highlighting the current HEAD commit row */
+.commit.blinking {
+  /* two short pulses */
+  animation: headPulse 320ms ease-in-out 2;
+}
+
+@keyframes headPulse {
+  0% { background-color: oklch(87.44% 0.2383 150 / 0.1); }
+  50% { background-color: oklch(87.44% 0.2383 150 / 0.5); }
+  100% { background-color: transparent; }
 }
 #actionRunning svg {
   display: inline-block;

--- a/media/main.css
+++ b/media/main.css
@@ -578,9 +578,15 @@ svg.fileIcon {
 }
 
 @keyframes headPulse {
-  0% { background-color: oklch(87.44% 0.2383 150 / 0.1); }
-  50% { background-color: oklch(87.44% 0.2383 150 / 0.5); }
-  100% { background-color: transparent; }
+  0% {
+    background-color: oklch(87.44% 0.2383 150 / 0.1);
+  }
+  50% {
+    background-color: oklch(87.44% 0.2383 150 / 0.5);
+  }
+  100% {
+    background-color: transparent;
+  }
 }
 #actionRunning svg {
   display: inline-block;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "typecheck": "tsc -p ./src --noEmit && tsc -p ./web --noEmit && tsc -p ./tests --noEmit",
     "vscode:prepublish": "pnpm run compile",
-    "clean": "rm -rf out",
+    "clean": "node -e \"require('fs').rmSync('out',{recursive:true,force:true})\"",
     "compile": "pnpm run clean && pnpm run compile-src && pnpm run compile-web",
     "compile-src": "esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify",
     "compile-web": "esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife",

--- a/src/extension/webviewHtml.ts
+++ b/src/extension/webviewHtml.ts
@@ -48,7 +48,8 @@ export function buildWebviewHtml(opts: {
 			<span id="repoControl"><span class="unselectable">Repo: </span><div id="repoSelect" class="dropdown"></div></span>
 			<span id="branchControl"><span class="unselectable">Branch: </span><div id="branchSelect" class="dropdown"></div></span>
 			<label id="showRemoteBranchesControl"><input type="checkbox" id="showRemoteBranchesCheckbox" value="1" checked>Show Remote Branches</label>
-			<div id="refreshBtn" class="roundedBtn">Refresh</div>
+      <div id="refreshBtn" class="roundedBtn">Refresh</div>
+      <div id="blinkHeadBtn" class="roundedBtn">Locate HEAD</div>
 		</div>
 		<div id="content">
 			<div id="commitGraph"></div>

--- a/tests/webview/setup.ts
+++ b/tests/webview/setup.ts
@@ -31,6 +31,7 @@ export function setupHtml(viewState: GG.GitGraphViewState) {
         Show Remote Branches
       </label>
       <div id="refreshBtn" class="roundedBtn">Refresh</div>
+      <div id="blinkHeadBtn" class="roundedBtn">Locate HEAD</div>
     </div>
     <div id="content">
       <div id="commitGraph"></div>

--- a/web/main.ts
+++ b/web/main.ts
@@ -465,7 +465,6 @@ class GitGraphView {
       ? '<div id="loadMoreCommitsBtn" class="roundedBtn">Load More Commits</div>'
       : "";
     this.makeTableResizable();
-    this.makeTableResizable();
 
     if (this.moreCommitsAvailable) {
       document.getElementById("loadMoreCommitsBtn")!.addEventListener("click", () => {

--- a/web/main.ts
+++ b/web/main.ts
@@ -13,7 +13,8 @@ import {
   sendMessage,
   svgIcons,
   unescapeHtml,
-  vscode
+  vscode,
+  blinkHeadRow
 } from "./utils";
 
 class GitGraphView {
@@ -85,6 +86,12 @@ class GitGraphView {
     document.getElementById("refreshBtn")!.addEventListener("click", () => {
       this.refresh(true);
     });
+    const blinkBtn = document.getElementById("blinkHeadBtn");
+    if (blinkBtn) {
+      blinkBtn.addEventListener("click", () => {
+        blinkHeadRow(this.commitHead);
+      });
+    }
     this.observeWindowSizeChanges();
     this.observeWebviewStyleChanges();
     this.observeWebviewScroll();
@@ -457,6 +464,7 @@ class GitGraphView {
     this.footerElem.innerHTML = this.moreCommitsAvailable
       ? '<div id="loadMoreCommitsBtn" class="roundedBtn">Load More Commits</div>'
       : "";
+    this.makeTableResizable();
     this.makeTableResizable();
 
     if (this.moreCommitsAvailable) {

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -83,6 +83,14 @@ export function addListenerToClass(className: string, event: string, eventListen
 export function insertAfter(newNode: HTMLElement, referenceNode: HTMLElement) {
   referenceNode.parentNode!.insertBefore(newNode, referenceNode.nextSibling);
 }
+export function blinkHeadRow(headHash: string | null) {
+  if (!headHash) return;
+  const row = document.querySelector(`tr.commit[data-hash="${headHash}"]`) as HTMLElement | null;
+  if (!row) return;
+  row.classList.add("blinking");
+  // Matches CSS animation: 320ms * 2 iterations = 640ms, add small buffer
+  window.setTimeout(() => row.classList.remove("blinking"), 700);
+}
 
 export function sendMessage(msg: GG.RequestMessage) {
   vscode.postMessage(msg);


### PR DESCRIPTION
Re-opened per request
This pull request adds a new "Locate HEAD" button to the UI, allowing users to visually highlight the current HEAD commit in the commit graph. It includes UI, style, and utility updates to support this feature, as well as a minor update to the `clean` script for cross-platform compatibility.

**Locate HEAD feature:**

* Adds a "Locate HEAD" button (`blinkHeadBtn`) to the toolbar in the main webview and test HTML to allow users to quickly find the HEAD commit. [[1]](diffhunk://#diff-3b48408451786572437587c069e9e7b5fdf932f3036073080ca41733b94184f3R52) [[2]](diffhunk://#diff-0df152dda801a73b56bab8d6f9999c1a1d27ef6801c8464e0c22c783b0e3598cR34)
* Implements the `blinkHeadRow` utility function, which triggers a CSS animation to highlight the HEAD commit row when the button is clicked. [[1]](diffhunk://#diff-ef97bac8fd3aae9f15e79ad88d16c61051b02e7c2e359056ab0b75aea407f4bfR86-R93) [[2]](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eL16-R17) [[3]](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eR89-R94)
* Adds CSS styles and keyframes for the blinking animation used to highlight the HEAD commit row, and styles for the new button. [[1]](diffhunk://#diff-97be685757c97d78b44aa2f32cf3816b46393b9ef5762010b18faeea503bfbddR406-R417) [[2]](diffhunk://#diff-97be685757c97d78b44aa2f32cf3816b46393b9ef5762010b18faeea503bfbddR573-R584)

**Other improvements:**

* Updates the `clean` script in `package.json` to use a cross-platform Node.js command instead of a Unix-specific `rm`.