### PR TITLE
fix: multi repo issue about #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,11 @@
       {
         "category": "(neo) Git Graph",
         "command": "neo-git-graph.view",
-        "title": "%command.view%"
+        "title": "%command.view%",
+        "icon": {
+          "light": "resources/webview-icon-light.svg",
+          "dark": "resources/webview-icon-dark.svg"
+        }
       },
       {
         "category": "(neo) Git Graph",
@@ -85,6 +89,15 @@
         "title": "%command.clearAvatarCache%"
       }
     ],
+    "menus": {
+      "scm/title": [
+        {
+          "command": "neo-git-graph.view",
+          "group": "navigation",
+          "when": "scmProvider == git"
+        }
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "%config.title%",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 
 import { AvatarManager } from "./avatarManager";
 import { gitClientFactory } from "./backend/gitClient";
-import { buildExtensionUri } from "./backend/utils/path";
+import { buildExtensionUri, getPathFromStr } from "./backend/utils/path";
 import { config } from "./config";
 import { DiffDocProvider } from "./diffDocProvider";
 import { registerMessageHandlers } from "./extension/messageHandler";
@@ -28,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
   const repoSearch = createRepoSearch(repoManager, config);
   const repoWatcher = createRepoWatcher(repoManager, config, repoSearch);
   let currentPanel: WebviewPanel | undefined;
+  let currentBridge: WebviewBridge | undefined;
 
   void (async () => {
     repoManager.removeReposNotInWorkspace();
@@ -38,9 +39,34 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     outputChannel,
-    vscode.commands.registerCommand("neo-git-graph.view", () => {
+    vscode.commands.registerCommand("neo-git-graph.view", (resource) => {
+      let repoPath: string | undefined;
+
+      if (resource && typeof resource === "object") {
+        if (typeof resource?.rootUri?.fsPath === "string") {
+          repoPath = getPathFromStr(resource.rootUri.fsPath);
+        } else if (typeof resource?.uri?.fsPath === "string") {
+          repoPath = getPathFromStr(resource.uri.fsPath);
+        }
+      }
+
+      const repos = repoManager.getRepos();
+
+      if (repoPath && !repos[repoPath]) repoPath = undefined;
+
       const column = vscode.window.activeTextEditor?.viewColumn;
       if (currentPanel) {
+        if (repoPath) {
+          gitClient.setRepo(repoPath);
+          extensionState.setLastActiveRepo(repoPath);
+          if (currentBridge) {
+            currentBridge.post({
+              command: "loadRepos",
+              repos: repos,
+              lastActiveRepo: repoPath
+            });
+          }
+        }
         currentPanel.reveal(column);
         return;
       }
@@ -61,6 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (panel.visible) bridge.post({ command: "refresh" });
       });
       bridge = webviewBridgeFactory(panel.webview, repoFileWatcher);
+      currentBridge = bridge;
       avatarManager.registerBridge(bridge.post.bind(bridge));
       const { onPanelShown } = registerMessageHandlers(bridge, {
         config,
@@ -79,8 +106,10 @@ export function activate(context: vscode.ExtensionContext) {
         extensionState,
         avatarManager,
         repoManager,
+        initialRepo: repoPath,
         onDispose: () => {
           currentPanel = undefined;
+          currentBridge = undefined;
         },
         onPanelShown
       });

--- a/src/extension/webviewPanel.ts
+++ b/src/extension/webviewPanel.ts
@@ -20,6 +20,7 @@ export function createWebviewPanel(opts: {
   extensionState: ExtensionState;
   avatarManager: AvatarManager;
   repoManager: RepoManager;
+  initialRepo?: string;
   onDispose: () => void;
   onPanelShown: () => void;
 }) {
@@ -32,9 +33,14 @@ export function createWebviewPanel(opts: {
     extensionState,
     avatarManager,
     repoManager,
+    initialRepo,
     onDispose,
     onPanelShown
   } = opts;
+
+  if (initialRepo) {
+    extensionState.setLastActiveRepo(initialRepo);
+  }
 
   const disposables: vscode.Disposable[] = [];
   let isGraphViewLoaded = false;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -125,7 +125,18 @@ class GitGraphView {
 
     let repoPaths = Object.keys(repos),
       changedRepo = false;
-    if (typeof repos[this.currentRepo] === "undefined") {
+    // Check if we need to update the current repo
+    if (
+      lastActiveRepo !== null &&
+      typeof repos[lastActiveRepo] !== "undefined" &&
+      lastActiveRepo !== this.currentRepo
+    ) {
+      // Explicitly switching to a different repo
+      this.currentRepo = lastActiveRepo;
+      this.saveState();
+      changedRepo = true;
+    } else if (typeof repos[this.currentRepo] === "undefined") {
+      // Current repo no longer exists
       this.currentRepo =
         lastActiveRepo !== null && typeof repos[lastActiveRepo] !== "undefined"
           ? lastActiveRepo
@@ -139,7 +150,10 @@ class GitGraphView {
       i;
     for (i = 0; i < repoPaths.length; i++) {
       repoComps = repoPaths[i].split("/");
-      options.push({ name: repoComps[repoComps.length - 1], value: repoPaths[i] });
+      options.push({
+        name: repoComps[repoComps.length - 1],
+        value: repoPaths[i]
+      });
     }
     document.getElementById("repoControl")!.style.display =
       repoPaths.length > 1 ? "inline" : "none";
@@ -517,14 +531,24 @@ class GitGraphView {
               showFormDialog(
                 l10n.dialogAddTagTitle.replace("{0}", "<b><i>" + abbrevCommit(hash) + "</i></b>"),
                 [
-                  { type: "text-ref" as const, name: l10n.dialogAddTagName, default: "" },
+                  {
+                    type: "text-ref" as const,
+                    name: l10n.dialogAddTagName,
+                    default: ""
+                  },
                   {
                     type: "select" as const,
                     name: l10n.dialogAddTagType,
                     default: "annotated",
                     options: [
-                      { name: l10n.dialogAddTagTypeAnnotated, value: "annotated" },
-                      { name: l10n.dialogAddTagTypeLightweight, value: "lightweight" }
+                      {
+                        name: l10n.dialogAddTagTypeAnnotated,
+                        value: "annotated"
+                      },
+                      {
+                        name: l10n.dialogAddTagTypeLightweight,
+                        value: "lightweight"
+                      }
                     ]
                   },
                   {
@@ -746,7 +770,11 @@ class GitGraphView {
           {
             title: l10n.copyCommitHash,
             onClick: () => {
-              sendMessage({ command: "copyToClipboard", type: "Commit Hash", data: hash });
+              sendMessage({
+                command: "copyToClipboard",
+                type: "Commit Hash",
+                data: hash
+              });
             }
           }
         ],
@@ -778,7 +806,11 @@ class GitGraphView {
                   .replace("{0}", l10n.labelTag)
                   .replace("{1}", "<b><i>" + escapeHtml(refName) + "</i></b>"),
                 () => {
-                  sendMessage({ command: "deleteTag", repo: this.currentRepo!, tagName: refName });
+                  sendMessage({
+                    command: "deleteTag",
+                    repo: this.currentRepo!,
+                    tagName: refName
+                  });
                 },
                 null
               );
@@ -793,7 +825,11 @@ class GitGraphView {
                   "<b><i>" + escapeHtml(refName) + "</i></b>"
                 ),
                 () => {
-                  sendMessage({ command: "pushTag", repo: this.currentRepo!, tagName: refName });
+                  sendMessage({
+                    command: "pushTag",
+                    repo: this.currentRepo!,
+                    tagName: refName
+                  });
                   showActionRunningDialog(l10n.pushingTag);
                 },
                 null
@@ -896,7 +932,11 @@ class GitGraphView {
       menu.push(null, {
         title: copyTitle,
         onClick: () => {
-          sendMessage({ command: "copyToClipboard", type: copyType, data: refName });
+          sendMessage({
+            command: "copyToClipboard",
+            type: copyType,
+            data: refName
+          });
         }
       });
       showContextMenu(<MouseEvent>e, menu, sourceElem);
@@ -1073,7 +1113,10 @@ class GitGraphView {
         this.repoDropdown.refresh();
         this.branchDropdown.refresh();
       }
-    }).observe(document.documentElement, { attributes: true, attributeFilter: ["style"] });
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style"]
+    });
   }
   private observeWebviewScroll() {
     let active = window.scrollY > 0;


### PR DESCRIPTION
| Q     | A              |
| ----- | -------------- |
| Type  | bugfix |
| Issue | Fix #43        |

- record `currentBridge` at `neo-git-graph.view` to communicate with webview
- when run `neo-git-graph.view`, it will auto switch the `currentRepo`
- `loadRepos` now can update `currentRepo` to the `lastActiveRepo`
- webview panel now can set initial repo